### PR TITLE
"Add OneSignal ID integration to CustomerIO identify flow

### DIFF
--- a/src/controllers/CustomerIO.ts
+++ b/src/controllers/CustomerIO.ts
@@ -1,21 +1,23 @@
 import { ORGANIZATION_ID, YOUR_SITE_ID } from "@config/customerIO";
 
+import { onesignalId } from "../helpers/oneSignalHelper";
+
 declare global {
-  interface Window {
-      _cio: unknown;
-  }
+    interface Window {
+        _cio: unknown;
+    }
 }
 
 /* eslint-disable*/
 function init() {
     if (typeof window !== "undefined") {
         window._cio = window._cio || [];
-        (function() {
+        (function () {
             let a, b, c;
-            a = function(f) {
-                return function() {
+            a = function (f) {
+                return function () {
                     _cio.push([ f ]
-                        .concat(Array.prototype.slice.call(arguments, 0)));
+                    .concat(Array.prototype.slice.call(arguments, 0)));
                 };
             };
             b = [ "load", "identify", "sidentify", "track", "page", "on", "off" ];
@@ -40,13 +42,14 @@ function init() {
     }
 }
 
-function cioIdentify({ id: idUser, email, created_at: createdProfile, ...data }) {
+function cioIdentify({id: idUser, email, created_at: createdProfile, ...data}) {
     const created_at = new Date(createdProfile).getTime() / 1000;
 
     _cio.identify({
         id: `rocketplay:${ idUser }`,
         email,
         created_at,
+        onesignal_id_web: onesignalId(),
         ...data,
     });
 }
@@ -62,4 +65,3 @@ export function cioIdentifyUser(userInfo) {
 
     cioIdentify(userInfo);
 }
-

--- a/src/helpers/oneSignalHelper.ts
+++ b/src/helpers/oneSignalHelper.ts
@@ -1,0 +1,7 @@
+import { ONESIGNAL_KEY_BY_HOST } from "@config/customerIO";
+
+export function onesignalId() {
+    if (typeof window !== "undefined") {
+        return ONESIGNAL_KEY_BY_HOST[window.location.hostname];
+    }
+}


### PR DESCRIPTION
Introduced a helper to fetch OneSignal IDs based on hostname and integrated it into the CustomerIO identification process. This ensures OneSignal IDs are passed along for better user tracking and communication."