### PR TITLE
Update dependencies in yarn.lock to their latest versions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -773,50 +773,50 @@
     proc-log "^5.0.0"
     which "^5.0.0"
 
-"@octokit/auth-app@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-app/-/auth-app-7.2.0.tgz#e81bcbf5c4278782210f60fbbf25a3e57ccdc09b"
-  integrity sha512-js6wDY3SNLNZo5XwybhC8WKEw8BonEa9vqxN4IKbhEbo22i2+DinHxapV/PpFCTsmlkT1HMhF75xyOG9RVvI5g==
+"@octokit/auth-app@^7.2.1":
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-app/-/auth-app-7.2.1.tgz#ed3d3ae487c5b42db88b10e95175d1a8a8965cbf"
+  integrity sha512-4jaopCVOtWN0V8qCx/1s2pkRqC6tcvIQM3kFB99eIpsP53GfsoIKO08D94b83n/V3iGihHmxWR2lXzE0NicUGg==
   dependencies:
-    "@octokit/auth-oauth-app" "^8.1.3"
-    "@octokit/auth-oauth-user" "^5.1.3"
-    "@octokit/request" "^9.2.1"
-    "@octokit/request-error" "^6.1.7"
-    "@octokit/types" "^13.8.0"
+    "@octokit/auth-oauth-app" "^8.1.4"
+    "@octokit/auth-oauth-user" "^5.1.4"
+    "@octokit/request" "^9.2.3"
+    "@octokit/request-error" "^6.1.8"
+    "@octokit/types" "^14.0.0"
     toad-cache "^3.7.0"
     universal-github-app-jwt "^2.2.0"
     universal-user-agent "^7.0.0"
 
-"@octokit/auth-oauth-app@^8.1.3":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-app/-/auth-oauth-app-8.1.3.tgz#42f53793dc9ea8bfbf69fbd1c072c6aaac944375"
-  integrity sha512-4e6OjVe5rZ8yBe8w7byBjpKtSXFuro7gqeGAAZc7QYltOF8wB93rJl2FE0a4U1Mt88xxPv/mS+25/0DuLk0Ewg==
+"@octokit/auth-oauth-app@^8.1.4":
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-app/-/auth-oauth-app-8.1.4.tgz#4a41ed59ae81c36215976e3523a671d5eacb6d52"
+  integrity sha512-71iBa5SflSXcclk/OL3lJzdt4iFs56OJdpBGEBl1wULp7C58uiswZLV6TdRaiAzHP1LT8ezpbHlKuxADb+4NkQ==
   dependencies:
-    "@octokit/auth-oauth-device" "^7.1.3"
-    "@octokit/auth-oauth-user" "^5.1.3"
-    "@octokit/request" "^9.2.1"
-    "@octokit/types" "^13.6.2"
+    "@octokit/auth-oauth-device" "^7.1.5"
+    "@octokit/auth-oauth-user" "^5.1.4"
+    "@octokit/request" "^9.2.3"
+    "@octokit/types" "^14.0.0"
     universal-user-agent "^7.0.0"
 
-"@octokit/auth-oauth-device@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-device/-/auth-oauth-device-7.1.3.tgz#c8b2d464bb1647839dcd5ba326ddec0a55ad6be8"
-  integrity sha512-BECO/N4B/Uikj0w3GCvjf/odMujtYTP3q82BJSjxC2J3rxTEiZIJ+z2xnRlDb0IE9dQSaTgRqUPVOieSbFcVzg==
+"@octokit/auth-oauth-device@^7.1.5":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-device/-/auth-oauth-device-7.1.5.tgz#dd22ed25539c4dadd27bfa3afccd244434fb4c48"
+  integrity sha512-lR00+k7+N6xeECj0JuXeULQ2TSBB/zjTAmNF2+vyGPDEFx1dgk1hTDmL13MjbSmzusuAmuJD8Pu39rjp9jH6yw==
   dependencies:
-    "@octokit/oauth-methods" "^5.1.4"
-    "@octokit/request" "^9.2.1"
-    "@octokit/types" "^13.6.2"
+    "@octokit/oauth-methods" "^5.1.5"
+    "@octokit/request" "^9.2.3"
+    "@octokit/types" "^14.0.0"
     universal-user-agent "^7.0.0"
 
-"@octokit/auth-oauth-user@^5.1.3":
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-user/-/auth-oauth-user-5.1.3.tgz#51808bad9157736044ad7f72217371d77f54aaf1"
-  integrity sha512-zNPByPn9K7TC+OOHKGxU+MxrE9SZAN11UHYEFLsK2NRn3akJN2LHRl85q+Eypr3tuB2GrKx3rfj2phJdkYCvzw==
+"@octokit/auth-oauth-user@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-user/-/auth-oauth-user-5.1.4.tgz#c8286e2812d0945e737563d94a1046b44078a06d"
+  integrity sha512-4tJRofMHm6ZCd3O2PVgboBbQ/lNtacREeaihet0+wCATZmvPK+jjg2K6NjBfY69An3yzQdmkcMeiaOOoxOPr7Q==
   dependencies:
-    "@octokit/auth-oauth-device" "^7.1.3"
-    "@octokit/oauth-methods" "^5.1.3"
-    "@octokit/request" "^9.2.1"
-    "@octokit/types" "^13.6.2"
+    "@octokit/auth-oauth-device" "^7.1.5"
+    "@octokit/oauth-methods" "^5.1.5"
+    "@octokit/request" "^9.2.3"
+    "@octokit/types" "^14.0.0"
     universal-user-agent "^7.0.0"
 
 "@octokit/auth-token@^5.0.0":
@@ -845,6 +845,14 @@
     "@octokit/types" "^13.6.2"
     universal-user-agent "^7.0.2"
 
+"@octokit/endpoint@^10.1.4":
+  version "10.1.4"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-10.1.4.tgz#8783be38a32b95af8bcb6523af20ab4eed7a2adb"
+  integrity sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==
+  dependencies:
+    "@octokit/types" "^14.0.0"
+    universal-user-agent "^7.0.2"
+
 "@octokit/graphql@^8.1.2":
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-8.2.1.tgz#0cb83600e6b4009805acc1c56ae8e07e6c991b78"
@@ -859,20 +867,25 @@
   resolved "https://registry.yarnpkg.com/@octokit/oauth-authorization-url/-/oauth-authorization-url-7.1.1.tgz#0e17c2225eb66b58ec902d02b6f1315ffe9ff04b"
   integrity sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA==
 
-"@octokit/oauth-methods@^5.1.3", "@octokit/oauth-methods@^5.1.4":
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/@octokit/oauth-methods/-/oauth-methods-5.1.4.tgz#767169b6541a5e26827a2c65b6066bdc48b4bd7a"
-  integrity sha512-Jc/ycnePClOvO1WL7tlC+TRxOFtyJBGuTDsL4dzXNiVZvzZdrPuNw7zHI3qJSUX2n6RLXE5L0SkFmYyNaVUFoQ==
+"@octokit/oauth-methods@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@octokit/oauth-methods/-/oauth-methods-5.1.5.tgz#647fcd135cedd2371452631ef131497e8037b008"
+  integrity sha512-Ev7K8bkYrYLhoOSZGVAGsLEscZQyq7XQONCBBAl2JdMg7IT3PQn/y8P0KjloPoYpI5UylqYrLeUcScaYWXwDvw==
   dependencies:
     "@octokit/oauth-authorization-url" "^7.0.0"
-    "@octokit/request" "^9.2.1"
-    "@octokit/request-error" "^6.1.7"
-    "@octokit/types" "^13.6.2"
+    "@octokit/request" "^9.2.3"
+    "@octokit/request-error" "^6.1.8"
+    "@octokit/types" "^14.0.0"
 
 "@octokit/openapi-types@^23.0.1":
   version "23.0.1"
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-23.0.1.tgz#3721646ecd36b596ddb12650e0e89d3ebb2dd50e"
   integrity sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==
+
+"@octokit/openapi-types@^25.0.0":
+  version "25.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-25.0.0.tgz#adeead36992abf966e89dcd53518d8b0dc910e0d"
+  integrity sha512-FZvktFu7HfOIJf2BScLKIEYjDsw6RKc7rBJCdvCTfKsVnx2GEB/Nbzjr29DUdb7vQhlzS/j8qDzdditP0OC6aw==
 
 "@octokit/plugin-paginate-rest@^11.0.0":
   version "11.4.2"
@@ -905,6 +918,13 @@
   dependencies:
     "@octokit/types" "^13.6.2"
 
+"@octokit/request-error@^6.1.8":
+  version "6.1.8"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-6.1.8.tgz#3c7ce1ca6721eabd43dbddc76b44860de1fdea75"
+  integrity sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==
+  dependencies:
+    "@octokit/types" "^14.0.0"
+
 "@octokit/request@^9.2.1", "@octokit/request@^9.2.2":
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-9.2.2.tgz#754452ec4692d7fdc32438a14e028eba0e6b2c09"
@@ -916,12 +936,30 @@
     fast-content-type-parse "^2.0.0"
     universal-user-agent "^7.0.2"
 
+"@octokit/request@^9.2.3":
+  version "9.2.3"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-9.2.3.tgz#00d023ad690903d952e4dd31e3f5804ef98fcd24"
+  integrity sha512-Ma+pZU8PXLOEYzsWf0cn/gY+ME57Wq8f49WTXA8FMHp2Ps9djKw//xYJ1je8Hm0pR2lU9FUGeJRWOtxq6olt4w==
+  dependencies:
+    "@octokit/endpoint" "^10.1.4"
+    "@octokit/request-error" "^6.1.8"
+    "@octokit/types" "^14.0.0"
+    fast-content-type-parse "^2.0.0"
+    universal-user-agent "^7.0.2"
+
 "@octokit/types@^13.6.2", "@octokit/types@^13.7.0", "@octokit/types@^13.8.0":
   version "13.8.0"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-13.8.0.tgz#3815885e5abd16ed9ffeea3dced31d37ce3f8a0a"
   integrity sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==
   dependencies:
     "@octokit/openapi-types" "^23.0.1"
+
+"@octokit/types@^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-14.0.0.tgz#bbd1d31e2269940789ef143b1c37918aae09adc4"
+  integrity sha512-VVmZP0lEhbo2O1pdq63gZFiGCKkm8PPp8AUOijlwPO6hojEVjspA0MWKP7E4hbvGxzFKNqKr6p0IYtOH/Wf/zA==
+  dependencies:
+    "@octokit/openapi-types" "^25.0.0"
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"


### PR DESCRIPTION
Bump multiple @octokit packages and their dependencies to ensure the project is using the latest versions. This includes updates to "@octokit/auth-app", "@octokit/request", and others, addressing improvements and fixes in the updated releases.