### PR TITLE
draft: refactor: UN-539: static pages filter to handle reactive data.

### DIFF
--- a/src/helpers/staticPages.ts
+++ b/src/helpers/staticPages.ts
@@ -1,3 +1,5 @@
+import { unref } from "vue";
+
 import { BOTTOM_MENU, CUSTOM_PAGE_TYPE, PAGE, TOP_MENU_TYPE } from "../consts/staticPages";
 import type { IPageCMSPrepare } from "../models/CMS";
 import type { IPageItemConfig } from "../services/api/DTO/CMS";
@@ -5,7 +7,7 @@ import type { IPageItemConfig } from "../services/api/DTO/CMS";
 function getPage(page: IPageItemConfig): IPageCMSPrepare {
     return {
         slug: page.path,
-        url: `/${page.path}`,
+        url: `/${ page.path }`,
         hidden: false,
         pageType: "static",
         ...page,
@@ -37,9 +39,14 @@ export function prepareMapStaticPages(pages: IPageItemConfig[]): IPageCMSPrepare
 const STATIC_PAGE_CATEGORIES = [ CUSTOM_PAGE_TYPE, TOP_MENU_TYPE, BOTTOM_MENU, PAGE ];
 
 export function filterStaticPages(allPages) {
-    return allPages.filter((page) => {
-        return page.categories.some((categoryItem) => {
-            return STATIC_PAGE_CATEGORIES.includes(categoryItem);
+    try {
+        const claerReactiveAllPages = JSON.parse(JSON.stringify(unref(allPages)));
+        return claerReactiveAllPages.filter((page) => {
+            return page.categories.some((categoryItem) => {
+                return STATIC_PAGE_CATEGORIES.includes(categoryItem);
+            });
         });
-    });
+    } catch (e) {
+        return [];
+    }
 }


### PR DESCRIPTION
Updated `filterStaticPages` to process reactive data by unwrapping and cloning it to ensure accuracy. Added error handling to safeguard against unexpected parsing issues, returning an empty array in case of failure.