### PR TITLE
fix: (UN-1172) Add user login check before sending PWA events

### DIFF
--- a/src/services/common.ts
+++ b/src/services/common.ts
@@ -47,5 +47,9 @@ export async function subscribeToStandaloneMQL() {
 }
 
 export async function sendPWAEvent(event: PWAEvent) {
-    await sendPWAEventReq(event);
+    const userStore = useUserInfo();
+
+    if (userStore.getIsLogged) {
+        await sendPWAEventReq(event);
+    }
 }


### PR DESCRIPTION
Ensure PWA events are only sent for logged-in users by introducing a check using the user store. This prevents unnecessary event requests and aligns with user authentication requirements.