### PR TITLE
feat: (UN-2957) add mirror cross-domain autologin handover

### DIFF
--- a/src/helpers/mirrorsAutologin.ts
+++ b/src/helpers/mirrorsAutologin.ts
@@ -1,0 +1,117 @@
+export const MIRRORS_AUTOLOGIN_DB_NAME = "SERVICE_WORKER";
+export const MIRRORS_AUTOLOGIN_STORE_NAME = "redirectModule";
+export const MIRRORS_AUTOLOGIN_RECOVERY_TOKEN_KEY = "rt";
+export const MIRRORS_AUTOLOGIN_COOKIE_NAME = "sso_token";
+export const MIRRORS_AUTOLOGIN_HANDOVER_PATH = "/handover";
+export const MIRRORS_AUTOLOGIN_REDEEM_PATH = "/api/sso/redeem";
+export const MIRRORS_AUTOLOGIN_ACCEPT_HEADER = "application/vnd.s.v1+json";
+
+function getIndexedDb(): IDBFactory | null {
+    return typeof indexedDB === "undefined" ? null : indexedDB;
+}
+
+function openAutologinDb(idb: IDBFactory): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+        const request = idb.open(MIRRORS_AUTOLOGIN_DB_NAME, 1);
+
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(MIRRORS_AUTOLOGIN_STORE_NAME)) {
+                db.createObjectStore(MIRRORS_AUTOLOGIN_STORE_NAME);
+            }
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+function putRecoveryToken(db: IDBDatabase, recoveryToken: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(MIRRORS_AUTOLOGIN_STORE_NAME, "readwrite");
+
+        tx.objectStore(MIRRORS_AUTOLOGIN_STORE_NAME).put(recoveryToken, MIRRORS_AUTOLOGIN_RECOVERY_TOKEN_KEY);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+    });
+}
+
+function getRecoveryToken(db: IDBDatabase): Promise<string> {
+    return new Promise((resolve) => {
+        const tx = db.transaction(MIRRORS_AUTOLOGIN_STORE_NAME, "readonly");
+        const request = tx.objectStore(MIRRORS_AUTOLOGIN_STORE_NAME).get(MIRRORS_AUTOLOGIN_RECOVERY_TOKEN_KEY);
+
+        request.onsuccess = () => {
+            resolve(typeof request.result === "string" ? request.result : "");
+        };
+        request.onerror = () => resolve("");
+    });
+}
+
+export function getCookieValue(name: string, cookieSource = typeof document === "undefined" ? "" : document.cookie): string {
+    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = cookieSource.match(new RegExp(`(?:^|; )${ escapedName }=([^;]*)`));
+
+    return match ? decodeURIComponent(match[1]) : "";
+}
+
+export async function setStoredMirrorsAutologinRecoveryToken(
+    recoveryToken: string,
+    idb: IDBFactory | null = getIndexedDb(),
+): Promise<boolean> {
+    if (!idb || !recoveryToken) {
+        return false;
+    }
+
+    let db: IDBDatabase | null = null;
+
+    try {
+        db = await openAutologinDb(idb);
+        await putRecoveryToken(db, recoveryToken);
+
+        return true;
+    } catch {
+        return false;
+    } finally {
+        db?.close();
+    }
+}
+
+export async function getStoredMirrorsAutologinRecoveryToken(
+    idb: IDBFactory | null = getIndexedDb(),
+): Promise<string> {
+    if (!idb) {
+        return "";
+    }
+
+    let db: IDBDatabase | null = null;
+
+    try {
+        db = await openAutologinDb(idb);
+
+        return await getRecoveryToken(db);
+    } catch {
+        return "";
+    } finally {
+        db?.close();
+    }
+}
+
+export async function persistMirrorsAutologinRecoveryToken(): Promise<boolean> {
+    const recoveryToken = getCookieValue(MIRRORS_AUTOLOGIN_COOKIE_NAME);
+
+    return setStoredMirrorsAutologinRecoveryToken(recoveryToken);
+}
+
+export function isValidMirrorsAutologinBackUrl(value: string | null): boolean {
+    if (!value || typeof value !== "string") {
+        return false;
+    }
+
+    try {
+        const parsedUrl = new URL(value);
+
+        return parsedUrl.protocol === "";
+    } catch {
+        return value.startsWith("/") && !value.startsWith("//") && !value.includes("\\");
+    }
+}

--- a/tests/helpers/mirrorsAutologin.test.ts
+++ b/tests/helpers/mirrorsAutologin.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+    getCookieValue,
+    getStoredMirrorsAutologinRecoveryToken,
+    isValidMirrorsAutologinBackUrl,
+    setStoredMirrorsAutologinRecoveryToken,
+} from "../../src/helpers/mirrorsAutologin";
+
+interface FakeIdbRequest<T = unknown> {
+    onerror?: ((event: Event) => void) | null;
+    onsuccess?: ((event: Event) => void) | null;
+    result?: T;
+}
+
+interface FakeIdbOpenRequest extends FakeIdbRequest<IDBDatabase> {
+    onupgradeneeded?: ((event: IDBVersionChangeEvent) => void) | null;
+}
+
+interface FakeIdbTransaction {
+    oncomplete?: ((event: Event) => void) | null;
+    onerror?: ((event: Event) => void) | null;
+    objectStore(name: string): IDBObjectStore;
+}
+
+function createFakeIndexedDb(): IDBFactory {
+    const values = new Map<string, unknown>();
+
+    return {
+        open: vi.fn(() => {
+            const request: FakeIdbOpenRequest = {};
+            const db = {
+                close: vi.fn(),
+                createObjectStore: vi.fn(),
+                objectStoreNames: {
+                    contains: vi.fn(() => false),
+                },
+                transaction: vi.fn(() => {
+                    const tx: FakeIdbTransaction = {
+                        objectStore: vi.fn(() => {
+                            return {
+                                get: vi.fn((key: string) => {
+                                    const getRequest: FakeIdbRequest = {};
+
+                                    queueMicrotask(() => {
+                                        getRequest.result = values.get(key);
+                                        getRequest.onsuccess?.({} as Event);
+                                    });
+
+                                    return getRequest as unknown as IDBRequest;
+                                }),
+                                put: vi.fn((value: string, key: string) => {
+                                    values.set(key, value);
+                                    queueMicrotask(() => tx.oncomplete?.({} as Event));
+                                }),
+                            } as unknown as IDBObjectStore;
+                        }),
+                    };
+
+                    return tx as unknown as IDBTransaction;
+                }),
+            };
+
+            queueMicrotask(() => {
+                request.result = db as unknown as IDBDatabase;
+                request.onupgradeneeded?.({} as IDBVersionChangeEvent);
+                request.onsuccess?.({} as Event);
+            });
+
+            return request as unknown as IDBOpenDBRequest;
+        }),
+    } as Partial<IDBFactory> as IDBFactory;
+}
+
+describe("mirrorsAutologin", () => {
+    it("reads and decodes a cookie value", () => {
+        expect(getCookieValue("sso_token", "locale=en; sso_token=token%20123; other=1")).toBe("token 123");
+    });
+
+    it("validates relative backUrl values only", () => {
+        expect(isValidMirrorsAutologinBackUrl("/games/slots?currency=EUR")).toBe(true);
+        expect(isValidMirrorsAutologinBackUrl("https://evil.test/path")).toBe(false);
+        expect(isValidMirrorsAutologinBackUrl("//evil.test/path")).toBe(false);
+        expect(isValidMirrorsAutologinBackUrl("/\\evil")).toBe(false);
+        expect(isValidMirrorsAutologinBackUrl(null)).toBe(false);
+    });
+
+    it("stores and reads the recovery token from shared IndexedDB layout", async() => {
+        const idb = createFakeIndexedDb();
+
+        expect(await setStoredMirrorsAutologinRecoveryToken("rt-123", idb)).toBe(true);
+        expect(await getStoredMirrorsAutologinRecoveryToken(idb)).toBe("rt-123");
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": [
-      "ESNext"
+      "ESNext",
+      "DOM"
     ],
     "allowJs": true,
     "strict": true,


### PR DESCRIPTION
- add shared mirrors autologin helper for sso_token persistence in IndexedDB
- store recovery token after successful auth profile load
- pass recovery token through service worker mirror fallback to /handover
- add /handover page to redeem token via /api/sso/redeem
- add no-store/referrer hardening headers for handover route
- add focused tests for helper, auth persistence, and handover route
- include DOM typings in unity-core-modules for existing IndexedDB usage